### PR TITLE
fix: add command line to force reinstall `libarchive`

### DIFF
--- a/Custom_Containerized_Environment.md
+++ b/Custom_Containerized_Environment.md
@@ -31,6 +31,7 @@ RUN sed -i  "s/archive.ubuntu.com/mirrors.ustc.edu.cn/g" /etc/apt/sources.list &
     apt-get install -y unzip python-opencv graphviz
 COPY environment.yml /tmp/environment.yml
 COPY pip_requirements.txt /tmp/pip_requirements.txt
+RUN conda install -n base libarchive -c main --force-reinstall --yes
 RUN conda env update --name base --file /tmp/environment.yml
 RUN conda clean --all --force-pkgs-dirs --yes
 RUN eval "$(conda shell.bash hook)" && \


### PR DESCRIPTION
If do not add this command, the error as follow will occur when cleaning cache files and temp files in `conda` :

```
Error while loading conda entry point: conda-libmamba-solver (libarchive.so.19: cannot open shared object file: No such file or directory)
```
Adding this command line will resolve the bug mentioned above.
```Dockerfile
RUN conda install -n base libarchive -c main --force-reinstall --yes
```